### PR TITLE
native implementation of axes with 3d projections

### DIFF
--- a/examples/fig_setup.py
+++ b/examples/fig_setup.py
@@ -38,7 +38,7 @@ def get_gridspec():
 
     return {
         # ### schematics
-        "arch": gs_tikz[0, 0],
+        "arch": (gs_tikz[0, 0], {'3d': True}),
 
         "coding": gs_tikz[0, 1],
 
@@ -72,11 +72,15 @@ def plot_labels(axes):
                          "coding",
                      ],
                      label_ypos={
-                         "arch": 0.87,
+                         "arch": 0.0,
                          "coding": 0.87,
                          "psp_shapes": 0.95,
                      },
                      label_xpos={
+                         "arch": 0.0,
+                     },
+                     label_zpos={
+                         "arch": 7.5,
                      },
                      )
 

--- a/gridspeccer/core.py
+++ b/gridspeccer/core.py
@@ -148,12 +148,18 @@ def make_axes(gridspec, fig_kwargs=None):
     for k, gs_item in list(gridspec.items()):
         # we just add a label to make sure all axes are actually created
         log.debug("Creating subplot: %s", k)
-        if isinstance(gs_item, gs.SubplotSpec):
-            axes[k] = fig.add_subplot(gs_item, label=k)
-        else:
-            # assume a tuple is given, and the second part are options
-            if '3d' in gs_item[1]:
-                axes[k] = fig.add_subplot(gs_item[0], label=k, projection='3d')
+        gs_props = {}
+        if isinstance(gs_item, tuple):
+            if len(gs_item) != 2 or not isinstance(gs_item[1], dict):
+                raise ValueError("Subplots should be specified either as SubplotSpec or (SubplotSpec, dict).")
+            gs_props = gs_item[1]
+            gs_item = gs_item[0]
+
+        kwargs = {"label": k}
+        if gs_props.get('3d', False):
+            kwargs['projection'] = '3d'
+
+        axes[k] = fig.add_subplot(gs_item, **kwargs)
 
     return fig, axes
 


### PR DESCRIPTION
The problem came up of including an axis that is a 3d projections. As MPL only allows this when creating an axis, this cannot be done straight forwardly in user code [1]. This commit adds core functionality and adapts the example to have one such axis.

[1] It can be done by using one of the following:
```
def plot_prosp_landscape(ax):
    # make the axis
    ax = plt.gcf().add_subplot(get_gridspec()["prosp_landscape"], projection='3d')
```
or (following not tested)
```
def plot_prosp_landscape(ax):
    # make the axis
    ax = plt.gcf().add_subplot(axis.properties()['gridspec'], projection='3d')
```
so recreating the axis, either from a completely new `gridspec` or from getting it from the current axis.
Not really neat solutions