### PR TITLE
fix tex workflow

### DIFF
--- a/.github/workflows/gsTexExample.yaml
+++ b/.github/workflows/gsTexExample.yaml
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
+        apt-get update
+        apt-get install -y python3-pip
         python3 -m pip install --upgrade pip
         pip install .
     - name: Make the plot


### PR DESCRIPTION
As described in https://github.com/dante-ev/docker-texlive/issues/37 python/pip were removed from the docker container of dante-ev, this breaks the workflow. 
This change explicitly adds the pip install.