### PR TITLE
Have a manually triggered workflow that creates a release with a bumped version

### DIFF
--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -19,7 +19,9 @@ jobs:
     - name: Bump version
       run: |
         i=${{github.event.inputs.versionNumber}}
-        [[ "$i" == '0' ]] || [[ "$i" == '1' ]] || [[ "$i" == '2' ]] || (echo "index must be 0, 1, or 2"; exit 1)
+        if [[ "$i" =~ [^0-9] ]] || (( i < 0 || i > 2 )); then
+          echo "index must be 0, 1, or 2"; exit 1;
+        fi
         oldversion=$(grep -Po 'VERSION = "\K[0-9.]*' setup.py)
         IFS="." read -a versionarray <<< $oldversion
         versionarray[${i}]=$((versionarray[${i}]+1))

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -1,0 +1,44 @@
+name: create a release with a bumped version number
+
+on:
+  workflow_dispatch:
+    inputs:
+      NumberIndex:
+        description: 'Index of version number that should be bumped (for version x.y.z we have 0:x,1:y,2:z, so the default 2 is a tiny release).'
+        required: true
+        default: '2'
+      releaseBody:
+        description: 'If you want the release to have a description'
+        required: false
+
+jobs:
+  installSetup:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Bump version
+      run: |
+        i=${{github.event.inputs.versionNumber}}
+        [[ "$i" == '0' ]] || [[ "$i" == '1' ]] || [[ "$i" == '2' ]] || (echo "index must be 0, 1, or 2"; exit 1)
+        oldversion=$(grep -Po 'VERSION = "\K[0-9.]*' setup.py)
+        IFS="." read -a versionarray <<< $oldversion
+        versionarray[${i}]=$((versionarray[${i}]+1))
+        newversion=$(IFS="."; echo "${versionarray[*]}")
+        echo "newversion=$newversion" >> $GITHUB_ENV
+        sed -i -E 's/VERSION = "'$oldversion'"/VERSION = "'$newversion'"/' setup.py
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git add -f setup.py
+        git commit -m "release ${newversion}"
+        git push origin
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.newversion }}
+          release_name: Release ${{ env.newversion }}
+          body: ${{github.event.inputs.releaseBody}}
+          draft: false
+          prerelease: false

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Bump version
       run: |
         i=${{github.event.inputs.versionNumber}}
-        if ! [[ "$i" =~ ^[012]$ ]]; then 
+        if ! [[ "$i" =~ ^[012]$ ]]; then
           echo "index must be 0, 1, or 2"; exit 1;
         fi
         oldversion=$(grep -Po 'VERSION = "\K[0-9.]*' setup.py)

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Bump version
       run: |
         i=${{github.event.inputs.versionNumber}}
-        if [[ "$i" =~ [^0-9] ]] || (( i < 0 || i > 2 )); then
+        if ! [[ "$i" =~ ^[012]$ ]]; then 
           echo "index must be 0, 1, or 2"; exit 1;
         fi
         oldversion=$(grep -Po 'VERSION = "\K[0-9.]*' setup.py)


### PR DESCRIPTION
@obreitwi not sure whether this will work, potential problems:
* `        [[ "$i" == '0' ]] || [[ "$i" == '1' ]] || [[ "$i" == '2' ]] || (echo "index must be 0, 1, or 2"; exit 1)` one needs to  check whether the input is an allowed one, is there a better way?
* not sure whether the release number string is correctly passed along, but [this](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable) suggests it should
* what kind of release action do we want? [the used repo](https://github.com/actions/create-release/) is read-only and not maintained, but the alternatives seemed too bloated