### PR TITLE
no dict as option takes just the value

### DIFF
--- a/gridspeccer/core.py
+++ b/gridspeccer/core.py
@@ -212,7 +212,7 @@ def plot_labels(
             ypos=label_ypos.get(label_idx, ypos_default),
             zpos=label_zpos.get(label_idx, zpos_default),
             color=label_color.get(label_idx, "k"),
-            size=label_size.get(label_idx, 16),
+            size=label_size.get(label_idx, 16) if isinstance(label_size, dict) else label_size,
             fontdict=fontdict,
         )
 


### PR DESCRIPTION
I was using #20 but was missing an option to set a uniform label size for all panels at once. I think this is a needed option, lmy what you think @Benano 
This way it can be
```python
    core.plot_labels(
        [...],
        label_size=12,
    )
```
instead of 
```python
    core.plot_labels(
        [...],
        label_size={"panela": 12, "panelb": 12, "panelc": 12, ...},
    )
```